### PR TITLE
Ensure proper artifact coordinates when publishing using gradle.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
 	id "com.jfrog.bintray" version "1.+"
+	id 'java-gradle-plugin'
 }
 
 apply plugin: "java"
@@ -45,12 +46,19 @@ publishing {
 
 			artifact sourcesJar
 			artifact javadocJar
-			afterEvaluate {
-				groupId = project.group
-			}
 		}
 	}
 }
+
+gradlePlugin {
+	plugins {
+		jasyptPlugin {
+			id = 'com.byteowls.jasypt'
+			implementationClass = 'com.byteowls.gradle.JasyptPlugin'
+        	}
+	}
+}	
+
 
 // ##########################
 // ### Publish to bintray ###

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'jasypt-gradle-plugin'
+rootProject.name = 'jasypt'

--- a/src/main/resources/META-INF/gradle-plugins/com.byteowls.jasypt.properties
+++ b/src/main/resources/META-INF/gradle-plugins/com.byteowls.jasypt.properties
@@ -1,1 +1,0 @@
-implementation-class=com.byteowls.gradle.JasyptPlugin


### PR DESCRIPTION
This PR updates the build.gradle file to use the `java-gradle-plugin` gradle publishing while publishing. These coordinates allow us to use gradle publish tasks to publish the project to an artifact repository. It also allows us to use the following plugin syntax is projects that use this plugin:

```
plugins {
    id 'com.byteowls.jasypt' version '1.1.0'
}
```